### PR TITLE
fix issue name in modtestplink

### DIFF
--- a/src/bindings/Fortran/modplink_miraculix.f90
+++ b/src/bindings/Fortran/modplink_miraculix.f90
@@ -118,7 +118,7 @@ subroutine plinkbedr_r8(namefile,geno,nids,nsnps,lfreq)
     if(io.ne.0)then
      write(*,'(a)')&
        'There is an issue during reading the Plink file.'// &
-       'modplink '// &
+       'modplink_miraculix '// &
        'plinkbedr_r8 ('//value2char(__LINE__)//')'
      error stop io
     endif
@@ -138,7 +138,7 @@ subroutine plinkbedr_r8(namefile,geno,nids,nsnps,lfreq)
  else
   write(*,'(a)')&
     'It is not a SNP-major bed file of plink!'// &
-    'modplink '// &
+    'modplink_miraculix '// &
     'plinkbedr_r8 ('//value2char(__LINE__)//')'
   close(un)
   error stop

--- a/src/bindings/Fortran/modtestplink.f90
+++ b/src/bindings/Fortran/modtestplink.f90
@@ -8,7 +8,7 @@
 
 module modtestplink
  use, intrinsic:: iso_fortran_env, only: int8, int32, real64
- use modplink, only: plinkbedr
+ use modplink_miraculix, only: plinkbedr
  implicit none
 
  private


### PR DESCRIPTION
An instance `modplink` must still be changed to `modplink_miraculix`.