### PR TITLE
Cast away imaginary part of eigen vectors

### DIFF
--- a/examples/gblup/calculate_gblup.jl
+++ b/examples/gblup/calculate_gblup.jl
@@ -80,7 +80,7 @@ function randomized_eigen(obj_ref::Ref{Ptr{Cvoid}}, snps::Int, indiv::Int, n::In
     # For documentation of hyperparameters, see Halko et al., 2011
     QR_rf = randomized_range_finder(obj_ref, snps, indiv, n + p, q)
     ZtZ_Q = multiply_ld(obj_ref, snps, indiv, QR_rf)
-    EV = eigvecs(transpose(QR_rf) * ZtZ_Q)
+    EV = real.(eigvecs(transpose(QR_rf) * ZtZ_Q))
     U = QR_rf * EV
 
     return U


### PR DESCRIPTION
Approximative eigen vectors can have non-negative imaginary part in randomized approximation algorithm. As this only affects the oversampled vectors, this has no negative impact on the rest of the process and therefore imaginary values can be safely cast away